### PR TITLE
Fix typo in print function

### DIFF
--- a/gateway-finder-imp.py
+++ b/gateway-finder-imp.py
@@ -92,7 +92,7 @@ def load_objects_new(options):
 				)
 
 			if not found_single_mac:
-				printc('[-] \t%d. This line does not contain valid MAC: "%s"' % (i,paint_s(lines[i],'orange')) )
+				print('[-] \t%d. This line does not contain valid MAC: "%s"' % (i,paint_s(lines[i],'orange')) )
 
 		if len(addresses['dst_macs'] ) != 0:
 			printc("[I] Will be using %d gateway MAC addresses" % len(addresses['dst_macs'] ),'green')


### PR DESCRIPTION
Fixed typo in print function. The `printc` function was used instead of `print` which was causing the following exception to be raised:

```
Traceback (most recent call last):
  File "./gateway-finder-imp.py", line 494, in <module>
    addresses = load_objects_new(args)
  File "./gateway-finder-imp.py", line 95, in load_objects_new
    printc('[-] \t%d. This line does not contain valid MAC: "%s"' % (i,paint_s(lines[i],'orange')) )
TypeError: printc() missing 1 required positional argument: 'color'
```